### PR TITLE
Peri/hawley us12 dashboard viewing parties

### DIFF
--- a/app/controllers/users/movies/viewing_parties_controller.rb
+++ b/app/controllers/users/movies/viewing_parties_controller.rb
@@ -32,7 +32,7 @@ class Users::Movies::ViewingPartiesController < ApplicationController
 
     def create_user_parties(ids, pid)
       if ids.present?
-        ids.each do |id|
+        ids.compact_blank.each do |id|
           UserParty.create(user_id: id, party_id: pid)
         end
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :get_user, only: [:show]
+
   def new
     @user = User.new
   end
@@ -14,11 +16,15 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @facade = MovieFacade
   end
 
   private
   def user_params
     params.require(:user).permit(:name, :email)
+  end
+
+  def get_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/facades/movie_facade.rb
+++ b/app/facades/movie_facade.rb
@@ -19,6 +19,20 @@ class MovieFacade
     end
   end
 
+  def self.get_movie_poster(id)
+    facade = create_facade(id)
+    facade.movie.poster
+  end
+
+  def self.get_movie_title(id)
+    facade = create_facade(id)
+    facade.movie.title
+  end
+
+  def self.create_facade(id)
+    MovieFacade.new(id)
+  end
+
   def movie_id
     movie.id
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,12 @@ module ApplicationHelper
   def count_reviews(reviews)
     reviews.count
   end
+
+  def format_date(date)
+    date.strftime("%B %d, %Y")
+  end
+
+  def format_time(time)
+    time.strftime("%l:%M %p").strip
+  end
 end

--- a/app/views/shared/_parties.html.erb
+++ b/app/views/shared/_parties.html.erb
@@ -1,0 +1,21 @@
+<h2> <%=title%> </h2>
+<% parties.each do |party| %>
+  <p><%= @facade.get_movie_title(party.movie_id)%>
+  <p><%= image_tag @facade.get_movie_poster(party.movie_id), size: "60x80" %></p>
+
+  <p><%= party.date %></p>
+  <p><%= party.start_time %></p>
+  <p>Host: <%= host=party.host_name %></p>
+  <div id='invitees'>
+  <p>Invited:</p>
+  <ul>
+  <% party.invited_users.each do |user| %>
+    <% if user.id == @user.id %>
+      <li><b><%= user.name %></b></li>
+    <% else %>
+      <li><%= user.name %></li>
+    <% end %>
+  <% end %>
+  </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_parties.html.erb
+++ b/app/views/shared/_parties.html.erb
@@ -3,8 +3,8 @@
   <p><%= @facade.get_movie_title(party.movie_id)%>
   <p><%= image_tag @facade.get_movie_poster(party.movie_id), size: "60x80" %></p>
 
-  <p><%= party.date %></p>
-  <p><%= party.start_time %></p>
+  <p><%= format_date(party.date) %></p>
+  <p><%= format_time(party.start_time) %></p>
   <p>Host: <%= host=party.host_name %></p>
   <div id='invitees'>
   <p>Invited:</p>

--- a/app/views/users/movies/show.html.erb
+++ b/app/views/users/movies/show.html.erb
@@ -7,6 +7,8 @@
 <p>Runtime: <%= format_runtime(@facade.movie_runtime) %></p>
 <p>Genre: <%= format_genres(@facade.movie_genres) %></p>
 
+<hr>
+
 <h3>Summary:</h3>
 <p><%= @facade.movie_summary %></p>
 

--- a/app/views/users/movies/viewing_parties/new.html.erb
+++ b/app/views/users/movies/viewing_parties/new.html.erb
@@ -4,20 +4,16 @@
 <br>
 <h2>Create a Movie Party for <%= @facade.movie_title %></h2>
 
-
+<h3>Viewing Party Details</h3>
+  <p>Movie Title: <%= @facade.movie_title %></p>
 <%= form_with url: user_movie_viewing_party_index_path(@user, @facade.movie_id), local: true do |f| %>
   <%= f.label :duration, 'Duration of Party' %>
-  <%= f.number_field :duration, value: @facade.movie_runtime, min: @facade.movie_runtime, max: 300 %>
+  <%= f.number_field :duration, value: @facade.movie_runtime, min: @facade.movie_runtime, max: 300 %><br><br>
   <%= f.label :date, 'Day' %>
-  <%= f.date_field :date %>
+  <%= f.date_field :date %><br><br>
   <%= f.label :start_time %>
-  <%= f.time_field :start_time %>
-  <p>Invite Users</p>
-  <% @users.each do |user| %>
-    <div id="invite_<%= user.id%>">
-    <%= check_box_tag 'invite[]', user.id %>
-    <%= label_tag 'invite[]', user.name %>
-    </div>
-  <% end %>
+  <%= f.time_field :start_time %><br><br>
+  <b><%= f.label :check_boxes, "Invite Users" %></b><br>
+  <%= f.collection_check_boxes :invite, @users, :id, :name %><br>
   <%= f.submit 'Create Party!' %>
-  <% end %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,4 +16,3 @@
                                       title: 'Parties Attending',
                                       parties: @user.invited_parties
   } %>
-</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,37 +3,17 @@
 <%= button_to 'Discover Movies', user_discover_path(@user), method: :get  %>
 <hr>
 
-<h2>Parties Hosting</h2>
-<% @user.hosted_parties.each do |party| %>
-  <div id='hosting'>
-  <p><%= party.date %></p>
-  <p><%= party.start_time %></p>
-  <p>Host: <%= @user.name %></p>
-  <p>Invited:</p>
-  <ul>
-  <% party.invited_users.each do |user| %>
-    <li><%= user.name %></li>
-  <% end %>
-  </ul>
-  </div>
-<% end %>
+<div id='hosting'>
+  <%= render partial: 'shared/parties', locals: {
+                                        title: 'Parties Hosting',
+                                        parties: @user.hosted_parties,
+                                        host: @user.name
+    } %>
+</div>
 
-<h2>Parties Attending</h2>
-<% @user.invited_parties.each do |party| %>
-  <div id='invited'>
-  <p><%= party.date %></p>
-  <p><%= party.start_time %></p>
-  <p>Host: <%= party.host_name %></p>
-  <p>Invited:</p>
-  <ul>
-  <% party.invited_users.each do |user| %>
-    <% if user.id == @user.id %>
-      <li><b><%= user.name %></b></li>
-    <% else %>
-      <li><%= user.name %></li>
-    <% end %>
-  <% end %>
-  </ul>
-  </div>
-<% end %>
-
+<div id='invited'>
+  <%= render partial: 'shared/parties', locals: {
+                                      title: 'Parties Attending',
+                                      parties: @user.invited_parties
+  } %>
+</div>

--- a/spec/facades/movie_facade_spec.rb
+++ b/spec/facades/movie_facade_spec.rb
@@ -1,83 +1,104 @@
 require 'rails_helper'
 
 RSpec.describe MovieFacade do
-  describe '#initialize' do
-    it 'creates an instance of a MovieFacade object with a given id' do
-      facade = MovieFacade.new(550)
-      expect(facade).to be_a(MovieFacade)
-    end
-  end
 
-  describe '#movie' do
-    it 'returns a movie object that stores all movie data needed for show page' do
+  describe 'class methods' do
+    describe 'get_movie_poster(id)' do
+      it 'creates a movie object and returns a poster URL when given a movie id as argument' do
       VCR.use_cassette('all_movie_data_by_id_550') do
-        movie = MovieFacade.new(550).movie
-
-        expect(movie).to be_a(Movie)
-        expect(movie.id).to be_a(Integer)
-        expect(movie.title).to be_a(String)
-        expect(movie.vote_average).to be_a(Float)
-        expect(movie.runtime).to be_a(Integer)
-        expect(movie.genres).to be_a(Array)
-        expect(movie.genres.first).to be_a(String)
-        expect(movie.summary).to be_a(String)
-        expect(movie.poster).to be_a(String)
+        expect(MovieFacade.get_movie_poster(550)).to be_a(String)
       end
-    end
-  end
-
-  describe '#reviews' do
-    it 'returns review objects that contain data for a specific movies reviews' do
-      VCR.use_cassette('all_review_data_by_id_550') do
-        reviews = MovieFacade.new(550).reviews
-
-        expect(reviews).to be_a(Array)
-        expect(reviews.first).to be_a(Review)
-
-        reviews.each do |review|
-          expect(review.author).to be_a(String)
-          expect(review.content).to be_a(String)
-        end
-      end
-    end
-  end
-
-  describe '#cast' do
-    it 'returns cast objects that contain data for a specific movies cast members' do
-      VCR.use_cassette('all_cast_data_by_id_550') do
-        cast = MovieFacade.new(550).cast
-
-        expect(cast).to be_a(Array)
-        expect(cast.first).to be_a(CastMember)
-
-        cast.each do |cast_member|
-          expect(cast_member.name).to be_a(String)
-          expect(cast_member.character).to be_a(String)
-        end
       end
     end
 
-    it 'returns an array of 10 cast member objects' do
-      VCR.use_cassette('all_cast_data_by_id_550') do
-        cast = MovieFacade.new(550).cast
-
-        expect(cast.count).to be <= 10
-      end
-    end
-  end
-
-  describe 'attribute methods' do
-    it 'they return movie attributes for display in the views' do
+    describe 'get_movie_title(id)' do
+      it 'creates a movie object and returns a title when given a movie id as argument' do
       VCR.use_cassette('all_movie_data_by_id_550') do
+        expect(MovieFacade.get_movie_title(550)).to be_a(String)
+      end
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    describe '#initialize' do
+      it 'creates an instance of a MovieFacade object with a given id' do
         facade = MovieFacade.new(550)
+        expect(facade).to be_a(MovieFacade)
+      end
+    end
 
-        expect(facade.movie_id).to be_a(Integer)
-        expect(facade.movie_title).to be_a(String)
-        expect(facade.movie_vote_average).to be_a(Float)
-        expect(facade.movie_runtime).to be_a(Integer)
-        expect(facade.movie_genres).to be_a(Array)
-        expect(facade.movie_summary).to be_a(String)
-        expect(facade.movie_poster).to be_a(String)
+    describe '#movie' do
+      it 'returns a movie object that stores all movie data needed for show page' do
+        VCR.use_cassette('all_movie_data_by_id_550') do
+          movie = MovieFacade.new(550).movie
+
+          expect(movie).to be_a(Movie)
+          expect(movie.id).to be_a(Integer)
+          expect(movie.title).to be_a(String)
+          expect(movie.vote_average).to be_a(Float)
+          expect(movie.runtime).to be_a(Integer)
+          expect(movie.genres).to be_a(Array)
+          expect(movie.genres.first).to be_a(String)
+          expect(movie.summary).to be_a(String)
+          expect(movie.poster).to be_a(String)
+        end
+      end
+    end
+
+    describe '#reviews' do
+      it 'returns review objects that contain data for a specific movies reviews' do
+        VCR.use_cassette('all_review_data_by_id_550') do
+          reviews = MovieFacade.new(550).reviews
+
+          expect(reviews).to be_a(Array)
+          expect(reviews.first).to be_a(Review)
+
+          reviews.each do |review|
+            expect(review.author).to be_a(String)
+            expect(review.content).to be_a(String)
+          end
+        end
+      end
+    end
+
+    describe '#cast' do
+      it 'returns cast objects that contain data for a specific movies cast members' do
+        VCR.use_cassette('all_cast_data_by_id_550') do
+          cast = MovieFacade.new(550).cast
+
+          expect(cast).to be_a(Array)
+          expect(cast.first).to be_a(CastMember)
+
+          cast.each do |cast_member|
+            expect(cast_member.name).to be_a(String)
+            expect(cast_member.character).to be_a(String)
+          end
+        end
+      end
+
+      it 'returns an array of 10 cast member objects' do
+        VCR.use_cassette('all_cast_data_by_id_550') do
+          cast = MovieFacade.new(550).cast
+
+          expect(cast.count).to be <= 10
+        end
+      end
+    end
+
+    describe 'attribute methods' do
+      it 'they return movie attributes for display in the views' do
+        VCR.use_cassette('all_movie_data_by_id_550') do
+          facade = MovieFacade.new(550)
+
+          expect(facade.movie_id).to be_a(Integer)
+          expect(facade.movie_title).to be_a(String)
+          expect(facade.movie_vote_average).to be_a(Float)
+          expect(facade.movie_runtime).to be_a(Integer)
+          expect(facade.movie_genres).to be_a(Array)
+          expect(facade.movie_summary).to be_a(String)
+          expect(facade.movie_poster).to be_a(String)
+        end
       end
     end
   end

--- a/spec/features/users/movies/viewing_parties/new_spec.rb
+++ b/spec/features/users/movies/viewing_parties/new_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe '/users/:id/movies/:id/viewing_party/new', type: :feature do
     @user3 = create(:user)
 
   end
-  
+
   describe 'When I visit the new viewing party page' do
-    
+
     it 'I see the name of the movie title' do
       VCR.use_cassette('find_movies_550', :allow_playback_repeats => true) do
         @movie = MovieFacade.new(550)
@@ -17,7 +17,7 @@ RSpec.describe '/users/:id/movies/:id/viewing_party/new', type: :feature do
         expect(page).to have_content("Create a Movie Party for #{@movie.movie_title}")
       end
     end
-      
+
     it 'I see a button to the discover page' do
       VCR.use_cassette('find_movies_550', :allow_playback_repeats => true) do
         @movie = MovieFacade.new(550)
@@ -38,15 +38,12 @@ RSpec.describe '/users/:id/movies/:id/viewing_party/new', type: :feature do
         fill_in :date, with: '2023/05/11'
         fill_in :start_time, with: Time.now
 
-        within "#invite_#{@user2.id}" do
-          check "#{@user2.name}"
-        end
+        check "#{@user2.name}"
 
         click_button 'Create Party!'
-
         expect(current_path).to eq(user_path(@user1))
-      end 
+      end
     end
-    # Sad path tests incoming. 
+    # Sad path tests incoming.
   end
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -6,56 +6,84 @@ RSpec.describe '/users/:id', type: :feature do
     @user2 = create(:user)
     @user3 = create(:user)
 
-    @party1 = create(:party, movie_id: 2, start_time: "04:30:45 UTC")
-    @party2 = create(:party, movie_id: 3, start_time: "04:35:30 UTC")
+    @party1 = create(:party, movie_id: 550, start_time: "04:30:45 UTC")
+    @party2 = create(:party, movie_id: 551, start_time: "04:35:30 UTC")
 
     @user_party1 = UserParty.create!(user: @user1, party: @party2)
     @user_party2 = UserParty.create!(user: @user3, party: @party1)
     @user_party3 = UserParty.create!(user: @user2, party: @party1)
     @user_party4 = UserParty.create!(user: @user1, party: @party1, is_host: true)
     @user_party5 = UserParty.create!(user: @user2, party: @party2, is_host: true)
-    visit user_path(@user1)
   end
 
   describe 'When I visit the users dashboard page' do
     it 'I see <users name> Dashboard" at the top of the page' do
-      expect(page).to have_content("#{@user1.name}'s Dashboard")
+      VCR.use_cassette('all_movie_data_by_id_550_551', :allow_playback_repeats => true) do
+        visit user_path(@user1)
+        expect(page).to have_content("#{@user1.name}'s Dashboard")
+      end
     end
 
     it 'has a button (Discover Movies)' do
-      expect(page).to have_button('Discover Movies')
+      VCR.use_cassette('all_movie_data_by_id_550_551', :allow_playback_repeats => true) do
+        visit user_path(@user1)
+        expect(page).to have_button('Discover Movies')
+      end
     end
 
     it 'has a section that list viewing parties' do
-      expect(page).to have_content('Parties Hosting')
-      expect(page).to have_content('Parties Attending')
+      VCR.use_cassette('all_movie_data_by_id_550_551', :allow_playback_repeats => true) do
+        title_550 = MovieFacade.get_movie_title(550)
+        title_551 = MovieFacade.get_movie_title(551)
+        poster_550 = MovieFacade.get_movie_poster(550)
+        poster_551 = MovieFacade.get_movie_poster(551)
 
-      within "#hosting" do
-        expect(page).to have_content(@party1.date)
-        expect(page).to have_content(@party1.start_time)
-        expect(page).to have_content("Host: #{@user1.name}")
-        expect(page).to have_content('Invited:')
-        expect(page).to have_content(@user2.name)
-        expect(page).to have_content(@user3.name)
-      end
+        visit user_path(@user1)
 
-      within "#invited" do
-        expect(page).to have_content(@party2.date)
-        expect(page).to have_content(@party2.start_time)
-        expect(page).to have_content("Host: #{@user2.name}")
-        expect(page).to have_content('Invited:')
-        expect(page).to have_content(@user1.name)
-        # expect(page).to_not have_content()
+        expect(page).to have_content('Parties Hosting')
+        expect(page).to have_content('Parties Attending')
+
+        within "#hosting" do
+          expect(page).to have_content(title_550)
+          # expect(page).to have_content(poster_550)
+          expect(page).to have_css('img')
+          expect(page).to have_content(@party1.date)
+          expect(page).to have_content(@party1.start_time)
+          expect(page).to have_content("Host: #{@user1.name}")
+          within "#invitees" do
+            expect(page).to have_content('Invited:')
+            expect(page).to have_content(@user2.name)
+            expect(page).to have_content(@user3.name)
+            expect(page).to_not have_content(@user1.name)
+          end
+        end
+
+        within "#invited" do
+          expect(page).to have_content(title_551)
+          # expect(page).to have_content(poster_551)
+          expect(page).to have_css('img')
+          expect(page).to have_content(@party2.date)
+          expect(page).to have_content(@party2.start_time)
+          expect(page).to have_content("Host: #{@user2.name}")
+          within "#invitees" do
+            expect(page).to have_content('Invited:')
+            expect(page).to have_content(@user1.name)
+            expect(page).to_not have_content(@user2.name)
+          end
+        end
       end
     end
   end
 
   describe 'When I visit the users dashboard page and click "Discover Movies"' do
     it 'redirects to a discover page for the specific user' do
-      click_button 'Discover Movies'
+      VCR.use_cassette('all_movie_data_by_id_550_551', :allow_playback_repeats => true) do
+        visit user_path(@user1)
+        click_button 'Discover Movies'
 
-      expect(current_path).to eq(user_discover_path(@user1))
-      expect(page).to have_content('Discover Movies')
+        expect(current_path).to eq(user_discover_path(@user1))
+        expect(page).to have_content('Discover Movies')
+      end
     end
   end
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -35,8 +35,6 @@ RSpec.describe '/users/:id', type: :feature do
       VCR.use_cassette('all_movie_data_by_id_550_551', :allow_playback_repeats => true) do
         title_550 = MovieFacade.get_movie_title(550)
         title_551 = MovieFacade.get_movie_title(551)
-        poster_550 = MovieFacade.get_movie_poster(550)
-        poster_551 = MovieFacade.get_movie_poster(551)
 
         visit user_path(@user1)
 
@@ -45,7 +43,6 @@ RSpec.describe '/users/:id', type: :feature do
 
         within "#hosting" do
           expect(page).to have_content(title_550)
-          # expect(page).to have_content(poster_550)
           expect(page).to have_css('img')
           expect(page).to have_content(@party1.date)
           expect(page).to have_content(@party1.start_time)
@@ -60,7 +57,6 @@ RSpec.describe '/users/:id', type: :feature do
 
         within "#invited" do
           expect(page).to have_content(title_551)
-          # expect(page).to have_content(poster_551)
           expect(page).to have_css('img')
           expect(page).to have_content(@party2.date)
           expect(page).to have_content(@party2.start_time)

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe '/users/:id', type: :feature do
         within "#hosting" do
           expect(page).to have_content(title_550)
           expect(page).to have_css('img')
-          expect(page).to have_content(@party1.date)
-          expect(page).to have_content(@party1.start_time)
+          expect(page).to have_content(format_date(@party1.date))
+          expect(page).to have_content(format_time(@party1.start_time))
           expect(page).to have_content("Host: #{@user1.name}")
           within "#invitees" do
             expect(page).to have_content('Invited:')
@@ -58,8 +58,8 @@ RSpec.describe '/users/:id', type: :feature do
         within "#invited" do
           expect(page).to have_content(title_551)
           expect(page).to have_css('img')
-          expect(page).to have_content(@party2.date)
-          expect(page).to have_content(@party2.start_time)
+          expect(page).to have_content(format_date(@party2.date))
+          expect(page).to have_content(format_time(@party2.start_time))
           expect(page).to have_content("Host: #{@user2.name}")
           within "#invitees" do
             expect(page).to have_content('Invited:')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,5 +21,19 @@ RSpec.describe ApplicationHelper do
         expect(count_reviews(reviews)).to eq(3)
       end
     end
+
+    describe '#format_date(date)' do
+      it 'formats a Date object to Month, Day Year format' do
+        date = '2023-05-16'.to_date
+        expect(format_date(date)).to eq('May 16, 2023')
+      end
+    end
+
+    describe '#format_time(time)' do
+      it 'formats a Time object to HH:MM AM or PM format' do
+        time = '2000-01-01 13:46:00 UTC'.to_time
+        expect(format_time(time)).to eq('1:46 PM')
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include ApplicationHelper
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
Pull request for User Story 12 - Dashboard:Viewing Parties

Check both boxes when completed - please explain below if boxes cannot be checked:

    [x] All Tests are Passing
    [x] The code will run locally

Type of change:

    [x] New Feature
    [] Bug Fix
    [x] Refactor

Implements/Fixes:

  Closes #12 

Check the correct boxes:

    [x] This broke nothing
    [] This broke some stuff
    [] This broke everything

Testing changes:

    [] No tests have been changed
    [x] Some tests have been added or changed
    [] All of the tests have been changed (Please describe what in the world happened!)

Checklist:

    [] My code has no unused/commented out code.  -- placeholders in for Sad Path testing
    [x] I have reviewed my code
    [x] I have commented my code if needed, particularly in hard-to-understand areas
    [x] I have fully tested my code

Note:
- Test coverage is still at 99.71%, we will address by adding sad path tests where commented in a later PR.
- This PR completes User Story 12 and finishes core functionality.  We have added the ability to display images and movie titles for each viewing party on a user's dashboard, with a call to the API (no data is stored in the database for movies). We adjusted our MovieFacade with class methods to fetch the necessary data, and instantiated a MovieFacade class in the controller. 
- This PR also includes a refactor for the new viewing party form to use the checkbox_collection helper, and refactors our User Dashboard page to use partials with local arguments to DRY up the view.